### PR TITLE
Support Lune 0.10

### DIFF
--- a/.luaurc
+++ b/.luaurc
@@ -1,6 +1,6 @@
 {
   "aliases": {
-    "lune": "~/.lune/.typedefs/0.9.4/"
+    "lune": "~/.lune/.typedefs/0.10.2/"
   },
   "languageMode": "strict",
   "lint": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "luau-lsp.require.useOriginalRequireByStringSemantics": true
+  "luau-lsp.platform.type": "standard"
 }

--- a/lune/convert-comments.luau
+++ b/lune/convert-comments.luau
@@ -1,4 +1,3 @@
-local stdio = require("@lune/stdio")
 local fs = require("@lune/fs")
 
 local result: { string } = {

--- a/lune/example.luau
+++ b/lune/example.luau
@@ -1,6 +1,4 @@
-local dirs = require("../src")
-local pathfs = require("../lune_packages/pathfs")
-local fs = pathfs.fs
+local dirs = require("../src/lib")
 
 local temp = dirs.createTempFile()
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,7 @@
+[settings]
+experimental = true
+
+[tools]
+"github:JohnnyMorganz/StyLua" = "latest"
+"github:JohnnyMorganz/luau-lsp" = "latest"
+"github:Kampfkarren/selene" = "latest"

--- a/pesde.lock
+++ b/pesde.lock
@@ -5,43 +5,39 @@ name = "jiwonz/dirs"
 version = "0.5.1"
 target = "lune"
 
-[graph."corecii/greentea@0.4.11 lune"]
-direct = ["greentea", { name = "corecii/greentea", version = "^0.4.10", index = "default" }, "standard"]
+[graph."jiwonz/greentea_luau@0.2.0 luau"]
+direct = ["greentea", { name = "jiwonz/greentea_luau", version = "^0.2.0", index = "default", target = "luau" }, "standard"]
 
-[graph."corecii/greentea@0.4.11 lune".pkg_ref]
+[graph."jiwonz/greentea_luau@0.2.0 luau".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/daimond113/pesde-index"
 
-[graph."jiwonz/luau_disk@0.1.4 luau".pkg_ref]
+[graph."jiwonz/luau_disk@0.2.0 luau".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."jiwonz/luau_path@0.1.4 luau".dependencies]
-luau_disk = ["jiwonz/luau_disk@0.1.4 luau", "standard"]
+[graph."jiwonz/luau_path@0.2.0 luau".dependencies]
+luau_disk = ["jiwonz/luau_disk@0.2.0 luau", "standard"]
 
-[graph."jiwonz/luau_path@0.1.4 luau".pkg_ref]
+[graph."jiwonz/luau_path@0.2.0 luau".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/pesde-pkg/index"
+
+[graph."jiwonz/luau_path@0.2.0 luau".pkg_ref.dependencies]
+luau_disk = [{ name = "jiwonz/luau_disk", version = "^0.2.0", index = "https://github.com/pesde-pkg/index" }, "standard"]
+
+[graph."jiwonz/pathfs@0.6.0 lune"]
+direct = ["pathfs", { name = "jiwonz/pathfs", version = "^0.6.0", index = "default" }, "standard"]
+
+[graph."jiwonz/pathfs@0.6.0 lune".dependencies]
+greentea = ["jiwonz/greentea_luau@0.2.0 luau", "standard"]
+luau_path = ["jiwonz/luau_path@0.2.0 luau", "standard"]
+
+[graph."jiwonz/pathfs@0.6.0 lune".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/daimond113/pesde-index"
 
-[graph."jiwonz/luau_path@0.1.4 luau".pkg_ref.dependencies]
-luau_disk = [{ name = "jiwonz/luau_disk", version = "^0.1.4", index = "https://github.com/pesde-pkg/index" }, "standard"]
-
-[graph."jiwonz/pathfs@0.6.0-rc.6 lune"]
-direct = ["pathfs", { name = "jiwonz/pathfs", version = "^0.6.0-rc.6", index = "default" }, "standard"]
-
-[graph."jiwonz/pathfs@0.6.0-rc.6 lune".dependencies]
-greentea = ["corecii/greentea@0.4.11 lune", "standard"]
-luau_path = ["jiwonz/luau_path@0.1.4 luau", "standard"]
-
-[graph."jiwonz/pathfs@0.6.0-rc.6 lune".pkg_ref]
-ref_ty = "pesde"
-index_url = "https://github.com/daimond113/pesde-index"
-
-[graph."jiwonz/pathfs@0.6.0-rc.6 lune".pkg_ref.dependencies]
-frktest = [{ name = "itsfrank/frktest", version = "^0.0.2", index = "https://github.com/daimond113/pesde-index" }, "dev"]
-greentea = [{ name = "corecii/greentea", version = "^0.4.11", index = "https://github.com/daimond113/pesde-index" }, "standard"]
-luau_check = [{ name = "jiwonz/luau_check", version = "^0.3.13", index = "https://github.com/daimond113/pesde-index" }, "dev"]
-luau_lsp = [{ name = "pesde/luau_lsp", version = "^1.48.0", index = "https://github.com/daimond113/pesde-index" }, "dev"]
-luau_path = [{ name = "jiwonz/luau_path", version = "^0.1.4", index = "https://github.com/daimond113/pesde-index", target = "luau" }, "standard"]
-selene = [{ name = "pesde/selene", version = "^0.28.0", index = "https://github.com/daimond113/pesde-index" }, "dev"]
-stylua = [{ name = "pesde/stylua", version = "^2.1.0", index = "https://github.com/daimond113/pesde-index" }, "dev"]
+[graph."jiwonz/pathfs@0.6.0 lune".pkg_ref.dependencies]
+frktest = [{ name = "itsfrank/frktest", version = "^0.0.4", index = "https://github.com/pesde-pkg/index", target = "luau" }, "dev"]
+greentea = [{ name = "jiwonz/greentea_luau", version = "^0.2.0", index = "https://github.com/pesde-pkg/index", target = "luau" }, "standard"]
+luau_path = [{ name = "jiwonz/luau_path", version = "^0.2.0", index = "https://github.com/pesde-pkg/index", target = "luau" }, "standard"]

--- a/pesde.toml
+++ b/pesde.toml
@@ -8,7 +8,7 @@ includes = ["src/**", "README.md", "pesde.toml", "LICENSE"]
 
 [target]
 environment = "lune"
-lib = "src/init.luau"
+lib = "src/lib.luau"
 
 [indices]
 default = "https://github.com/daimond113/pesde-index"

--- a/pesde.toml
+++ b/pesde.toml
@@ -14,9 +14,9 @@ lib = "src/init.luau"
 default = "https://github.com/daimond113/pesde-index"
 
 [engines]
-lune = "^0.9.0"
-pesde = "^0.7.0-rc.1"
+lune = "^0.10.2"
+pesde = "^0.7.1"
 
 [dependencies]
-pathfs = { name = "jiwonz/pathfs", version = "^0.6.0-rc.6" }
-greentea = { name = "corecii/greentea", version = "^0.4.10" }
+pathfs = { name = "jiwonz/pathfs", version = "^0.6.0" }
+greentea = { name = "jiwonz/greentea_luau", version = "^0.2.0", target = "luau" }

--- a/rokit.toml
+++ b/rokit.toml
@@ -1,9 +1,0 @@
-# This file lists tools managed by Rokit, a toolchain manager for Roblox projects.
-# For more information, see https://github.com/rojo-rbx/rokit
-
-# New tools can be added by running `rokit add <tool>` in a terminal.
-
-[tools]
-luau-lsp = "JohnnyMorganz/luau-lsp@1.50.0"
-selene = "Kampfkarren/selene@0.28.0"
-StyLua = "JohnnyMorganz/StyLua@2.1.0"

--- a/src/lib.luau
+++ b/src/lib.luau
@@ -2,7 +2,7 @@ local process = require("@lune/process")
 local targetOS = process.os
 local types = require("./types")
 local pathfs = require("../lune_packages/pathfs")
-local gt = require("../lune_packages/greentea")
+local gt = require("../luau_packages/greentea")
 
 local sys: types.Sys? = if targetOS == "windows"
 	then require("./win")
@@ -334,7 +334,9 @@ end
 local createTemp = require("./utils/createTemp")
 local optionalStringType = gt.build(gt.opt(gt.string()))
 local optionalNumberType = gt.build(gt.opt(gt.number()))
-local optionalAsPathType = gt.build(gt.opt(pathfs.types.AsPath:type()))
+local optionalAsPathType = gt.build(gt.opt(gt.custom(function(value)
+	return pcall(pathfs.Path.from, value)
+end, "AsPath") :: pathfs.AsPath))
 
 --[=[
 	Creates a temporary directory.
@@ -351,13 +353,13 @@ function dirs.createTempDir(
 	prefix: typeof(optionalStringType:type()),
 	suffix: typeof(optionalStringType:type()),
 	randomLength: typeof(optionalNumberType:type())
-): pathfs.Directory
+): pathfs.DirectoryPath
 	optionalAsPathType:assert(base)
 	optionalStringType:assert(prefix)
 	optionalStringType:assert(suffix)
 	optionalNumberType:assert(randomLength)
 
-	return pathfs.Directory.fromExisting(createTemp(true, base, prefix, suffix, randomLength))
+	return pathfs.DirectoryPath.fromExisting(createTemp(true, base, prefix, suffix, randomLength))
 end
 
 --[=[
@@ -375,13 +377,13 @@ function dirs.createTempFile(
 	prefix: typeof(optionalStringType:type()),
 	suffix: typeof(optionalStringType:type()),
 	randomLength: typeof(optionalNumberType:type())
-): pathfs.File
+): pathfs.FilePath
 	optionalAsPathType:assert(base)
 	optionalStringType:assert(prefix)
 	optionalStringType:assert(suffix)
 	optionalNumberType:assert(randomLength)
 
-	return pathfs.File.fromExisting(createTemp(false, base, prefix, suffix, randomLength))
+	return pathfs.FilePath.fromExisting(createTemp(false, base, prefix, suffix, randomLength))
 end
 
 return dirs

--- a/src/sys/init.luau
+++ b/src/sys/init.luau
@@ -1,7 +1,7 @@
 local process = require("@lune/process")
 local env = process.env
 local targetOS = process.os
-local pathfs = require("../../lune_packages/pathfs")
+local pathfs = require("../lune_packages/pathfs")
 local fs = pathfs.fs
 
 local sys = {}
@@ -28,7 +28,7 @@ if targetOS == "linux" then
 		homeDir = homeDir,
 		isAbsolutePath = isAbsolutePath,
 	}
-	local xdgUserDirs = require("./xdgUserDirs")
+	local xdgUserDirs = require("@self/xdgUserDirs")
 
 	local function userDirFile(home: pathfs.Path): pathfs.Path
 		return (isAbsolutePath(env.XDG_CONFIG_HOME) or home:join(".config")):join("user-dirs.dirs")
@@ -65,9 +65,9 @@ if targetOS == "windows" then
 		homeDir = homeDir,
 		isAbsolutePath = isAbsolutePath,
 	}
-	local KNOWNFOLDERID = require("../win32/KNOWNFOLDERID")
-	local defaultKnownFolderPaths = require("../win32/defaultKnownFolderPaths")
-	local parsePath = require("../win32/parsePath")
+	local KNOWNFOLDERID = require("./win32/KNOWNFOLDERID")
+	local defaultKnownFolderPaths = require("./win32/defaultKnownFolderPaths")
+	local parsePath = require("./win32/parsePath")
 
 	--[=[
 		Due to lack of lune-ffi built-in library, there's no way to call SHGetKnownFolderPath. so we're going to dlopen via powershell temporary.


### PR DESCRIPTION
Closes #4 

- Use mise instead of rokit
- Change greentea package to greentea-luau
- Migrate pathfs to 0.6 which supports Lune 0.10
- Resolve old requires for newer require
- Change pesde lib entry to `src/lib.luau` (previously `src/init.luau`)
- Update Lune typedefs to Lune 0.10's one
- Remove luau-lsp `useOriginalRequireByStringSemantics` setting